### PR TITLE
Fix include path on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,18 +6,13 @@ use std::path::PathBuf;
 
 fn try_main() -> Result<()> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
-    let project_dir = {
-        let mut r = PathBuf::from(file!()).canonicalize()?;
-        r.pop();
-        r
-    };
 
     // Configure C build
     env::set_var(
         "CFLAGS",
         format!(
             "-I{dir}/vendor/xxhash/ {old}",
-            dir = project_dir.display(),
+            dir = env::var("CARGO_MANIFEST_DIR")?,
             old = env::var("CFLAGS").unwrap_or("".to_string())
         ),
     );


### PR DESCRIPTION
Looks like MSVC doesn't support canonicalized paths such as `-I\\\\?\\C:\\Users\\r\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\xxhrs-0.0.2/vendor/xxhash/` so was failing to build on Windows.

So fixed it here to use `CARGO_MANIFEST_DIR` which is easier and more robust