### PR TITLE
Fixed UB from `MaybeUninit<T>::assume_init()` by manually zero-initializing buffer and padding fields.

### DIFF
--- a/src/xxh3.rs
+++ b/src/xxh3.rs
@@ -71,7 +71,15 @@ impl XXH3_64<'_> {
     pub fn new() -> XXH3_64<'static> {
         unsafe {
             let mut r = MaybeUninit::<C::XXH3_state_t>::uninit();
-            C::XXH3_64bits_reset(r.as_mut_ptr() as *mut C::XXH3_state_t);
+            let r_ptr = r.as_mut_ptr();
+            // SAFETY: Writes to padding fields may be optimized away on the C
+            // side since they are never accessed. To avoid UB from
+            // r.assume_uninit(), we initialize them to 0. The field `buffer`
+            // is also not fully initialized across the FFI so we zero it out, too.
+            (*r_ptr).reserved32 = 0;
+            (*r_ptr).reserved64 = 0;
+            (*r_ptr).buffer = [0; 256];
+            C::XXH3_64bits_reset(r_ptr as *mut C::XXH3_state_t);
             XXH3_64 {
                 state: r.assume_init(),
                 entropy_lifetime: PhantomData,
@@ -97,8 +105,16 @@ impl XXH3_64<'_> {
     pub unsafe fn with_entropy_buffer(entropy: &[u8]) -> XXH3_64 {
         assert!(entropy.len() >= (C::XXH3_SECRET_SIZE_MIN) as usize);
         let mut r = MaybeUninit::<C::XXH3_state_t>::uninit();
+        // SAFETY: Writes to padding fields may be optimized away on the C
+        // side since they are never accessed. To avoid UB from
+        // r.assume_uninit(), we initialize them to 0. The field `buffer`
+        // is also not fully initialized across the FFI so we zero it out, too.
+        let r_ptr = r.as_mut_ptr();
+        (*r_ptr).reserved32 = 0;
+        (*r_ptr).reserved64 = 0;
+        (*r_ptr).buffer = [0; 256];
         C::XXH3_64bits_reset_withSecret(
-            r.as_mut_ptr() as *mut C::XXH3_state_t,
+            r_ptr as *mut C::XXH3_state_t,
             entropy.as_ptr() as *const c_void,
             entropy.len() as u64,
         );
@@ -115,8 +131,16 @@ impl XXH3_64<'_> {
     pub fn with_entropy(entropy: &EntropyPool) -> XXH3_64<'static> {
         unsafe {
             let mut r = MaybeUninit::<C::XXH3_state_t>::uninit();
+            let r_ptr = r.as_mut_ptr();
+            // SAFETY: Writes to padding fields may be optimized away on the C
+            // side since they are never accessed. To avoid UB from
+            // r.assume_uninit(), we initialize them to 0. The field `buffer`
+            // is also not fully initialized across the FFI so we zero it out, too.
+            (*r_ptr).reserved32 = 0;
+            (*r_ptr).reserved64 = 0;
+            (*r_ptr).buffer = [0; 256];
             C::XXHRS_64bits_reset_withSecretCopy(
-                r.as_mut_ptr() as *mut C::XXH3_state_t,
+                r_ptr as *mut C::XXH3_state_t,
                 entropy.entropy.as_ptr() as *const c_void,
             );
             XXH3_64 {
@@ -131,7 +155,15 @@ impl XXH3_64<'_> {
     pub fn with_seed(seed: u64) -> XXH3_64<'static> {
         unsafe {
             let mut r = MaybeUninit::<C::XXH3_state_t>::uninit();
-            C::XXH3_64bits_reset_withSeed(r.as_mut_ptr() as *mut C::XXH3_state_t, seed);
+            let r_ptr = r.as_mut_ptr();
+            // SAFETY: Writes to padding fields may be optimized away on the C
+            // side since they are never accessed. To avoid UB from
+            // r.assume_uninit(), we initialize them to 0. The field `buffer`
+            // is also not fully initialized across the FFI so we zero it out, too.
+            (*r_ptr).reserved32 = 0;
+            (*r_ptr).reserved64 = 0;
+            (*r_ptr).buffer = [0; 256];
+            C::XXH3_64bits_reset_withSeed(r_ptr as *mut C::XXH3_state_t, seed);
             XXH3_64 {
                 state: r.assume_init(),
                 entropy_lifetime: PhantomData,
@@ -239,7 +271,15 @@ impl XXH3_128<'_> {
     pub fn new() -> XXH3_128<'static> {
         unsafe {
             let mut r = MaybeUninit::<C::XXH3_state_t>::uninit();
-            C::XXH3_128bits_reset(r.as_mut_ptr() as *mut C::XXH3_state_t);
+            let r_ptr = r.as_mut_ptr();
+            // SAFETY: Writes to padding fields may be optimized away on the C
+            // side since they are never accessed. To avoid UB from
+            // r.assume_uninit(), we initialize them to 0. The field `buffer`
+            // is also not fully initialized across the FFI so we zero it out, too.
+            (*r_ptr).reserved32 = 0;
+            (*r_ptr).reserved64 = 0;
+            (*r_ptr).buffer = [0; 256];
+            C::XXH3_128bits_reset(r_ptr as *mut C::XXH3_state_t);
             XXH3_128 {
                 state: r.assume_init(),
                 entropy_lifetime: PhantomData,
@@ -265,8 +305,16 @@ impl XXH3_128<'_> {
     pub unsafe fn with_entropy_buffer(entropy: &[u8]) -> XXH3_128 {
         assert!(entropy.len() >= (C::XXH3_SECRET_SIZE_MIN) as usize);
         let mut r = MaybeUninit::<C::XXH3_state_t>::uninit();
+        let r_ptr = r.as_mut_ptr();
+        // SAFETY: Writes to padding fields may be optimized away on the C
+        // side since they are never accessed. To avoid UB from
+        // r.assume_uninit(), we initialize them to 0. The field `buffer`
+        // is also not fully initialized across the FFI so we zero it out, too.
+        (*r_ptr).reserved32 = 0;
+        (*r_ptr).reserved64 = 0;
+        (*r_ptr).buffer = [0; 256];
         C::XXH3_128bits_reset_withSecret(
-            r.as_mut_ptr() as *mut C::XXH3_state_t,
+            r_ptr as *mut C::XXH3_state_t,
             entropy.as_ptr() as *const c_void,
             entropy.len() as u64,
         );
@@ -283,8 +331,16 @@ impl XXH3_128<'_> {
     pub fn with_entropy(entropy: &EntropyPool) -> XXH3_128<'static> {
         unsafe {
             let mut r = MaybeUninit::<C::XXH3_state_t>::uninit();
+            let r_ptr = r.as_mut_ptr();
+            // SAFETY: Writes to padding fields may be optimized away on the C
+            // side since they are never accessed. To avoid UB from
+            // r.assume_uninit(), we initialize them to 0. The field `buffer`
+            // is also not fully initialized across the FFI so we zero it out, too.
+            (*r_ptr).reserved32 = 0;
+            (*r_ptr).reserved64 = 0;
+            (*r_ptr).buffer = [0; 256];
             C::XXHRS_128bits_reset_withSecretCopy(
-                r.as_mut_ptr() as *mut C::XXH3_state_t,
+                r_ptr as *mut C::XXH3_state_t,
                 entropy.entropy.as_ptr() as *const c_void,
             );
             XXH3_128 {
@@ -299,7 +355,15 @@ impl XXH3_128<'_> {
     pub fn with_seed(seed: u64) -> XXH3_128<'static> {
         unsafe {
             let mut r = MaybeUninit::<C::XXH3_state_t>::uninit();
-            C::XXH3_128bits_reset_withSeed(r.as_mut_ptr() as *mut C::XXH3_state_t, seed);
+            let r_ptr = r.as_mut_ptr();
+            // SAFETY: Writes to padding fields may be optimized away on the C
+            // side since they are never accessed. To avoid UB from
+            // r.assume_uninit(), we initialize them to 0. The field `buffer`
+            // is also not fully initialized across the FFI so we zero it out, too.
+            (*r_ptr).reserved32 = 0;
+            (*r_ptr).reserved64 = 0;
+            (*r_ptr).buffer = [0; 256];
+            C::XXH3_128bits_reset_withSeed(r_ptr as *mut C::XXH3_state_t, seed);
             XXH3_128 {
                 state: r.assume_init(),
                 entropy_lifetime: PhantomData,

--- a/src/xxhash.rs
+++ b/src/xxhash.rs
@@ -45,7 +45,12 @@ impl XXH32 {
     pub fn with_seed(seed: u32) -> XXH32 {
         unsafe {
             let mut r = MaybeUninit::<C::XXH32_state_t>::uninit();
-            C::XXH32_reset(r.as_mut_ptr() as *mut C::XXH32_state_t, seed);
+            // SAFETY: Writes to padding fields may be optimized away on the C
+            // side since they are never accessed. To avoid UB from
+            // r.assume_uninit(), we initialize them to 0.
+            let r_ptr = r.as_mut_ptr();
+            (*r_ptr).reserved = 0;
+            C::XXH32_reset(r_ptr as *mut C::XXH32_state_t, seed);
             XXH32 {
                 state: r.assume_init(),
             }
@@ -106,7 +111,13 @@ impl XXH64 {
     pub fn with_seed(seed: u64) -> XXH64 {
         unsafe {
             let mut r = MaybeUninit::<C::XXH64_state_t>::uninit();
-            C::XXH64_reset(r.as_mut_ptr() as *mut C::XXH64_state_t, seed);
+            // SAFETY: Writes to padding fields may be optimized away on the C
+            // side since they are never accessed. To avoid UB from
+            // r.assume_uninit(), we initialize them to 0.
+            let r_ptr = r.as_mut_ptr();
+            (*r_ptr).reserved32 = 0;
+            (*r_ptr).reserved64 = 0;
+            C::XXH64_reset(r_ptr as *mut C::XXH64_state_t, seed);
             XXH64 {
                 state: r.assume_init(),
             }


### PR DESCRIPTION
Several structs have padding fields which are never accessed. These include `XXH3_state_s`, `XXH64_state_s`, and `XXH32_state_s`. The C initializers for these structs zero out their memory, which *should* initialize the padding fields, too. For example, here's the initializer for `XXH64_state_s`:

```
XXH_errorcode XXH64_reset(XXH_NOESCAPE XXH64_state_t* statePtr, ...)
{
    ...
    memset(statePtr, 0, sizeof(*statePtr));
    ...
    return XXH_OK;
}
```
However, it seems like LLVM avoids copying fields which are never accessed, which leaves them uninitialized. 
```
define i32 @xxhrs_equodaeyiejoopibaeva_XXH64_reset(ptr noundef %0, i64 noundef %1) {
  %3 = alloca ptr, align 8
  %4 = alloca i64, align 8
  %5 = alloca %struct.XXH64_state_s, align 8
  ...
  call void @llvm.memset.p0.i64(ptr align 8 %5, i8 0, i64 88, i1 false)
  ...
  %19 = load ptr, ptr %3, align 8
  call void @llvm.memcpy.p0.p0.i64(ptr align 8 %19, ptr align 8 %5, i64 80, i1 false)
  ret i32 0
}
```
Notice that the size of `XXH64_state_s` is 88, so it is fully zero-initialized by  full struct `llvm.memset.p0.i64`. However, only 80 bytes are copied back into the return pointer by `llvm.memcpy.p0.p0.i64`, which leaves the padding fields uninitialized. Since `MaybeUninit<T>` requires all bytes to be initialized prior to calling `assume_init()`, this leads to undefined behavior in Rust.

This patch fixes the issue by manually initializing the padding fields in Rust as well as the field `buffer` of the struct `XXH3_state_s`, which is not used for padding but doesn't seem to be fully initialized by C.