### PR TITLE
Updated bindgen, applied rustfmt and clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ random_entropy = ["getrandom"]
 getrandom = { version = "0.2.0", optional = true }
 
 [build-dependencies]
-bindgen = "0.55.1"
+bindgen = "0.69.2"
 cc = { version = "1.0.59", features = ["parallel"] }
 anyhow = "1.0.32"
 shell-words = "1.0.0"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -313,7 +313,10 @@ where
 
     fn end(&mut self) -> Result<&mut JsonSerializer<W>> {
         let what = self.stack.pop().unwrap();
-        assert!(matches!(what, JsonStackFrame::Array(_)|JsonStackFrame::Object(_)));
+        assert!(matches!(
+            what,
+            JsonStackFrame::Array(_) | JsonStackFrame::Object(_)
+        ));
         self.w.write_all(match what {
             JsonStackFrame::Object(_) => b"}",
             JsonStackFrame::Array(_) => b"]",

--- a/build.rs
+++ b/build.rs
@@ -29,8 +29,7 @@ fn try_main() -> Result<()> {
         .header("src/xxhash_bindings.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .rustfmt_bindings(true)
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .generate()
         .expect("Unable to generate bindings")
         .write_to_file(out_dir.join("xxhash_bindings.rs"))

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -24,7 +24,7 @@ pub const ENTROPY_POOL_SIZE: usize = C::XXH3_SECRET_DEFAULT_SIZE as usize;
 /// for instance using HMAC-SHA256 or Kekkac, but this is probably overkill.
 #[derive(Clone)]
 pub struct EntropyPool {
-    pub entropy: [u8; ENTROPY_POOL_SIZE as usize],
+    pub entropy: [u8; ENTROPY_POOL_SIZE],
 }
 
 impl PartialEq for EntropyPool {
@@ -78,7 +78,7 @@ impl EntropyPool {
             C::XXH3_generateSecret(
                 r.entropy.as_mut_ptr() as *mut c_void,
                 key.as_ptr() as *const c_void,
-                key.len() as u64,
+                key.len(),
             );
         }
         r

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ mod xxhash;
 
 // Tests //
 
-#[cfg(all(test))]
+#[cfg(test)]
 mod tests;
 
 #[cfg(doctest)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -141,7 +141,7 @@ fn test_streaming() {
             test_stream!($out <- $var);
             test_stream!($($rest)*);
         }};
-    };
+    }
 
     test_stream!(
         XXH32_HASH   <- XXH32::new(),
@@ -257,7 +257,7 @@ fn test_hash_set() {
                 assert!(hs.insert(ix));
             }
         }};
-    };
+    }
 
     test_random_state!(RandomStateXXH64);
     test_random_state!(RandomStateXXH3_64);
@@ -270,7 +270,7 @@ fn test_debug_print() {
         ($in:expr, $out:expr) => {
             assert_eq!(format!("{:?}", $in), $out);
         };
-    };
+    }
 
     let pool = EntropyPool {
         entropy: [42u8; ENTROPY_POOL_SIZE],

--- a/src/xxh3.rs
+++ b/src/xxh3.rs
@@ -22,7 +22,7 @@ impl XXH3_64<'_> {
     /// One-shot hashing
     #[inline]
     pub fn hash(bytes: &[u8]) -> u64 {
-        unsafe { C::XXH3_64bits(bytes.as_ptr() as *const c_void, bytes.len() as u64) }
+        unsafe { C::XXH3_64bits(bytes.as_ptr() as *const c_void, bytes.len()) }
     }
 
     /// One-shot hashing with custom entropy buffer.
@@ -44,9 +44,9 @@ impl XXH3_64<'_> {
         assert!(entropy.len() >= (C::XXH3_SECRET_SIZE_MIN) as usize);
         C::XXH3_64bits_withSecret(
             bytes.as_ptr() as *const c_void,
-            bytes.len() as u64,
+            bytes.len(),
             entropy.as_ptr() as *const c_void,
-            entropy.len() as u64,
+            entropy.len(),
         )
     }
 
@@ -61,9 +61,7 @@ impl XXH3_64<'_> {
     /// One-shot hashing with seed
     #[inline]
     pub fn hash_with_seed(seed: u64, bytes: &[u8]) -> u64 {
-        unsafe {
-            C::XXH3_64bits_withSeed(bytes.as_ptr() as *const c_void, bytes.len() as u64, seed)
-        }
+        unsafe { C::XXH3_64bits_withSeed(bytes.as_ptr() as *const c_void, bytes.len(), seed) }
     }
 
     /// Streaming hashing
@@ -100,7 +98,7 @@ impl XXH3_64<'_> {
         C::XXH3_64bits_reset_withSecret(
             r.as_mut_ptr() as *mut C::XXH3_state_t,
             entropy.as_ptr() as *const c_void,
-            entropy.len() as u64,
+            entropy.len(),
         );
         XXH3_64 {
             state: r.assume_init(),
@@ -147,7 +145,7 @@ impl Hasher for XXH3_64<'_> {
             C::XXH3_64bits_update(
                 &mut self.state,
                 bytes.as_ptr() as *const c_void,
-                bytes.len() as u64,
+                bytes.len(),
             );
         }
     }
@@ -187,7 +185,7 @@ impl XXH3_128<'_> {
     /// One-shot hashing
     #[inline]
     pub fn hash(bytes: &[u8]) -> u128 {
-        let r = unsafe { C::XXH3_128bits(bytes.as_ptr() as *const c_void, bytes.len() as u64) };
+        let r = unsafe { C::XXH3_128bits(bytes.as_ptr() as *const c_void, bytes.len()) };
         xxh128_to_u128(r)
     }
 
@@ -210,9 +208,9 @@ impl XXH3_128<'_> {
         assert!(entropy.len() >= (C::XXH3_SECRET_SIZE_MIN) as usize);
         let r = C::XXH3_128bits_withSecret(
             bytes.as_ptr() as *const c_void,
-            bytes.len() as u64,
+            bytes.len(),
             entropy.as_ptr() as *const c_void,
-            entropy.len() as u64,
+            entropy.len(),
         );
         xxh128_to_u128(r)
     }
@@ -228,9 +226,8 @@ impl XXH3_128<'_> {
     /// One-shot hashing with seed
     #[inline]
     pub fn hash_with_seed(seed: u64, bytes: &[u8]) -> u128 {
-        let r = unsafe {
-            C::XXH3_128bits_withSeed(bytes.as_ptr() as *const c_void, bytes.len() as u64, seed)
-        };
+        let r =
+            unsafe { C::XXH3_128bits_withSeed(bytes.as_ptr() as *const c_void, bytes.len(), seed) };
         xxh128_to_u128(r)
     }
 
@@ -268,7 +265,7 @@ impl XXH3_128<'_> {
         C::XXH3_128bits_reset_withSecret(
             r.as_mut_ptr() as *mut C::XXH3_state_t,
             entropy.as_ptr() as *const c_void,
-            entropy.len() as u64,
+            entropy.len(),
         );
         XXH3_128 {
             state: r.assume_init(),
@@ -313,7 +310,7 @@ impl XXH3_128<'_> {
             C::XXH3_128bits_update(
                 &mut self.state,
                 bytes.as_ptr() as *const c_void,
-                bytes.len() as u64,
+                bytes.len(),
             );
         }
     }

--- a/src/xxhash.rs
+++ b/src/xxhash.rs
@@ -31,7 +31,7 @@ impl XXH32 {
     /// One-shot hashing with seed
     #[inline]
     pub fn hash_with_seed(seed: u32, bytes: &[u8]) -> u32 {
-        unsafe { C::XXH32(bytes.as_ptr() as *const c_void, bytes.len() as u64, seed) }
+        unsafe { C::XXH32(bytes.as_ptr() as *const c_void, bytes.len(), seed) }
     }
 
     /// Streaming hashing
@@ -58,7 +58,7 @@ impl XXH32 {
             C::XXH32_update(
                 &mut self.state,
                 bytes.as_ptr() as *const c_void,
-                bytes.len() as u64,
+                bytes.len(),
             );
         }
     }
@@ -92,7 +92,7 @@ impl XXH64 {
     /// One-shot hashing with seed
     #[inline]
     pub fn hash_with_seed(seed: u64, bytes: &[u8]) -> u64 {
-        unsafe { C::XXH64(bytes.as_ptr() as *const c_void, bytes.len() as u64, seed) }
+        unsafe { C::XXH64(bytes.as_ptr() as *const c_void, bytes.len(), seed) }
     }
 
     /// Streaming hashing
@@ -121,7 +121,7 @@ impl Hasher for XXH64 {
             C::XXH64_update(
                 &mut self.state,
                 bytes.as_ptr() as *const c_void,
-                bytes.len() as u64,
+                bytes.len(),
             );
         }
     }


### PR DESCRIPTION
The current version of bindgen (55.1) emits layout tests that cause instantaneous UB by dereferencing null pointers. Updating to 69.2 fixes this issue. As a consequence, several bindings are changed slightly to accept `usize` instead of `u64`. This patch also applies several formatting suggestions from Clippy and rustfmt.